### PR TITLE
Fix script shebangs in README.md and  use bash instead of zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub SBOM Collection Script
 
-A zsh script to generate Software Bill of Materials (SBOM) for all repositories owned by a GitHub user or organization using the GitHub CLI.
+A bash script to generate Software Bill of Materials (SBOM) for all repositories owned by a GitHub user or organization using the GitHub CLI.
 
 ## Prerequisites
 

--- a/gh-sbom-all.sh
+++ b/gh-sbom-all.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 # SBOM Collection Script for GitHub Repositories
 # Usage: ./gh-sbom-all.sh <repo-owner>

--- a/monitor_progress.sh
+++ b/monitor_progress.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 # Simple progress monitor for the SBOM generation script
 


### PR DESCRIPTION
This pull request updates the script files and documentation to switch from `zsh` to `bash` for compatibility and consistency. 

Script updates:

* [`gh-sbom-all.sh`](diffhunk://#diff-f4d40eee55e57f73814a85a9cc5c54b99e68fa5b2d1531ff8e525bc39296db08L1-R1): Changed the shebang from `#!/bin/zsh` to `#!/bin/bash` to indicate the script should be executed using Bash.
* [`monitor_progress.sh`](diffhunk://#diff-81321a92d3ece9f2af173718e20c8481b133c6cab63aebc1bf79b4f8e6f52611L1-R1): Updated the shebang from `#!/bin/zsh` to `#!/bin/bash` for consistency across scripts.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the description to reflect the change from a zsh script to a bash script.